### PR TITLE
chore: remove the `-policy` suffix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,8 @@ jobs:
     uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-rust.yml@v1
     with:
       input-wasm: volumemounts_policy
-      oci-target: ghcr.io/kubewarden/policies/volumemounts-policy
-    
+      oci-target: ghcr.io/kubewarden/policies/volumemounts
+
     secrets:
       workflow-pat: ${{ secrets.WORKFLOW_PAT }}
-    
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volumemounts-policy"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Víctor Cuadrado Juan <vcuadradojuan@suse.de>"]
 edition = "2018"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.0
+version: 0.1.1
 name: volumemounts
 displayName: volumeMounts
 createdAt: '2022-07-19T16:39:10+02:00'
@@ -11,7 +11,7 @@ license: Apache-2.0
 homeURL: https://kubewarden.io
 containersImages:
 - name: policy
-  image: "ghcr.io/kubewarden/policies/volumemounts-policy:v0.1.0"
+  image: "ghcr.io/kubewarden/policies/volumemounts:v0.1.1"
 keywords:
 - container
 - volumeMounts

--- a/metadata.yml
+++ b/metadata.yml
@@ -7,7 +7,7 @@ mutating: false
 contextAware: false
 executionMode: kubewarden-wapc
 annotations:
-  io.kubewarden.policy.title: volumemounts-policy
+  io.kubewarden.policy.title: volumemounts
   io.kubewarden.policy.description: Policy that inspects containers, init containers, and ephemeral containers, and restricts their usage of volumes by  checking the `volume` name being used in `volumeMounts[*].name`
   io.kubewarden.policy.author: Víctor Cuadrado Juan <vcuadradojuan@suse.de>
   io.kubewarden.policy.url: https://github.com/yourorg/volumemounts-policy


### PR DESCRIPTION
Remove the `-policy` suffix from metadata, artifacthub and from the OCI name.
