### PR TITLE
fix: Use `volumeMountsNames` everywhere, error if empty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "volumemounts-policy"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volumemounts-policy"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Víctor Cuadrado Juan <vcuadradojuan@suse.de>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -29,16 +29,16 @@ Both have trade-offs:
 ## Settings
 ```yaml
 reject: anyIn # one of anyIn (default, denylist), anyNotIn (allowlist), allAreUsed, notAllAreUsed
-volumeMountNames:  # list of volumeMounts.name to match using the defined reject operator
+volumeMountsNames:  # list of volumeMounts.name to match using the defined reject operator
   - foo
   - bar
   - baz
 ```
 
-- `anyIn` (default): checks if any of the volumeMountNames are in the Pod/Workload resource
-- `anyNotIn`: checks if any of the volumeMountNames are not in the Pod/Workload resource
-- `allAreUsed`: checks if all of the volumeMountNames are in the Pod/Workload resource
-- `notAllAreUsed`: checks if all of the volumeMountNames are not in the Pod/Workload resource
+- `anyIn` (default): checks if any of the volumeMountsNames are in the Pod/Workload resource
+- `anyNotIn`: checks if any of the volumeMountsNames are not in the Pod/Workload resource
+- `allAreUsed`: checks if all of the volumeMountsNames are in the Pod/Workload resource
+- `notAllAreUsed`: checks if all of the volumeMountsNames are not in the Pod/Workload resource
 
 ## Examples
 
@@ -53,7 +53,7 @@ volumeMountsNames:
 ```yaml
 # allowlist, only allow volumeMounts named `my-volume3` or `my-volume4`
 reject: anyNotIn
-volumeMounts:
+volumeMountsNames:
   - my-volume3
   - my-volume4
 ```
@@ -61,7 +61,7 @@ volumeMounts:
 ```yaml
 # container cannot use both volumes at once, only one or the other
 reject: allAreUsed
-volumeMounts:
+volumeMountsNames:
   - my-volume5
   - my-volume6
 ```
@@ -69,7 +69,7 @@ volumeMounts:
 ```yaml
 # container can use both volumes at once, but not only one of them
 reject: notAllAreSused
-volumeMounts:
+volumeMountsNames:
   - my-volume5
   - my-volume6
 ```

--- a/metadata.yml
+++ b/metadata.yml
@@ -14,70 +14,70 @@ annotations:
   io.kubewarden.policy.source: https://github.com/yourorg/volumemounts-policy
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.usage: |
-   The policy can either target `Pods`, or [workload
-   resources](https://kubernetes.io/docs/concepts/workloads/) (`Deployments`,
-   `ReplicaSets`, `DaemonSets`, `ReplicationControllers`, `Jobs`, `CronJobs`) by
-   setting the policy's `spec.rules` accordingly.
+    The policy can either target `Pods`, or [workload
+    resources](https://kubernetes.io/docs/concepts/workloads/) (`Deployments`,
+    `ReplicaSets`, `DaemonSets`, `ReplicationControllers`, `Jobs`, `CronJobs`) by
+    setting the policy's `spec.rules` accordingly.
 
-   Both have trade-offs:
-   * Policy targets Pods: Different kind of resources (be them native or CRDs) can
-     create Pods. By having the policy target Pods, we guarantee that all the Pods
-     are going to be compliant, even those created from CRDs.
-     However, this could lead to confusion among users, as high level Kubernetes
-     resources would be successfully created, but they would stay in a non
-     reconciled state. Example: a Deployment creating a non-compliant Pod would be
-     created, but it would never have all its replicas running.
-   * Policy targets workload resources (e.g: Deployment): the policy inspect higher
-     order resource (e.g. Deployment): users will get immediate feedback about
-     rejections.
-     However, non compliant pods created by another high level resource (be it
-     native to Kubernetes, or a CRD), may not get rejected.
+    Both have trade-offs:
+    * Policy targets Pods: Different kind of resources (be them native or CRDs) can
+      create Pods. By having the policy target Pods, we guarantee that all the Pods
+      are going to be compliant, even those created from CRDs.
+      However, this could lead to confusion among users, as high level Kubernetes
+      resources would be successfully created, but they would stay in a non
+      reconciled state. Example: a Deployment creating a non-compliant Pod would be
+      created, but it would never have all its replicas running.
+    * Policy targets workload resources (e.g: Deployment): the policy inspect higher
+      order resource (e.g. Deployment): users will get immediate feedback about
+      rejections.
+      However, non compliant pods created by another high level resource (be it
+      native to Kubernetes, or a CRD), may not get rejected.
 
 
-   ## Settings
-   ```yaml
-   reject: anyIn # one of anyIn (default, denylist), anyNotIn (allowlist), allIn, allNotIn
-   volumeMountNames:  # list of volumeMounts.name to match using the defined rejectOperator
-     - foo
-     - bar
-     - baz
-   ```
+    ## Settings
+    ```yaml
+    reject: anyIn # one of anyIn (default, denylist), anyNotIn (allowlist), allAreUsed, notAllAreUsed
+    volumeMountsNames:  # list of volumeMounts.name to match using the defined reject operator
+      - foo
+      - bar
+      - baz
+    ```
 
-   - `allIn` checks if all of the volumeMountNames are in the Pod
-   - `anyIn` checks if any of the volumeMountNames are in the Pod
-   - `allNotIn` checks if all of the volumeMountNames are not in the Pod
-   - `anyNotIn` checks if any of the volumeMountNames are not in the Pod
+    - `anyIn` (default): checks if any of the volumeMountsNames are in the Pod/Workload resource
+    - `anyNotIn`: checks if any of the volumeMountsNames are not in the Pod/Workload resource
+    - `allAreUsed`: checks if all of the volumeMountsNames are in the Pod/Workload resource
+    - `notAllAreUsed`: checks if all of the volumeMountsNames are not in the Pod/Workload resource
 
-   ## Examples
+    ## Examples
 
-   ```yaml
-   # denylist, reject volumeMounts named `my-volume` or `my-volume2`
-   reject: anyIn
-   volumeMountsNames:
-     - my-volume
-     - my-volume2
-   ```
+    ```yaml
+    # denylist, reject volumeMounts named `my-volume` or `my-volume2`
+    reject: anyIn
+    volumeMountsNames:
+      - my-volume
+      - my-volume2
+    ```
 
-   ```yaml
-   # allowlist, only allow volumeMounts named `my-volume3` or `my-volume4`
-   reject: anyNotIn
-   volumeMounts:
-     - my-volume3
-     - my-volume4
-   ```
+    ```yaml
+    # allowlist, only allow volumeMounts named `my-volume3` or `my-volume4`
+    reject: anyNotIn
+    volumeMountsNames:
+      - my-volume3
+      - my-volume4
+    ```
 
-   ```yaml
-   # container cannot use both volumes at once, only one or the other
-   reject: allIn
-   volumeMounts:
-     - my-volume5
-     - my-volume6
-   ```
+    ```yaml
+    # container cannot use both volumes at once, only one or the other
+    reject: allAreUsed
+    volumeMountsNames:
+      - my-volume5
+      - my-volume6
+    ```
 
-   ```yaml
-   # container can use both volumes at once, but not only one of them
-   reject: allNotIn
-   volumeMounts:
-     - my-volume5
-     - my-volume6
-   ```
+    ```yaml
+    # container can use both volumes at once, but not only one of them
+    reject: notAllAreSused
+    volumeMountsNames:
+      - my-volume5
+      - my-volume6
+    ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,16 +119,16 @@ fn validate_volume_mounts(
     volume_mounts: &[VolumeMount],
     settings: &settings::Settings,
 ) -> Result<()> {
-    let mut volume_mount_names: HashSet<String> = HashSet::new();
+    let mut volume_mounts_names: HashSet<String> = HashSet::new();
     for mount in volume_mounts {
-        volume_mount_names.insert(mount.name.to_string());
+        volume_mounts_names.insert(mount.name.to_string());
     }
     match settings.operator {
         settings::Reject::AllAreUsed => {
             // cannot use both at once, only one or the other
-            if settings.volume_mount_names.is_subset(&volume_mount_names) {
+            if settings.volume_mounts_names.is_subset(&volume_mounts_names) {
                 let mut sorted_names = settings
-                    .volume_mount_names
+                    .volume_mounts_names
                     .clone()
                     .into_iter()
                     .collect::<Vec<String>>();
@@ -143,8 +143,8 @@ fn validate_volume_mounts(
         settings::Reject::AnyIn => {
             // denylist
             let intersection: HashSet<_> = settings
-                .volume_mount_names
-                .intersection(&volume_mount_names)
+                .volume_mounts_names
+                .intersection(&volume_mounts_names)
                 .collect();
             match intersection.is_empty() {
                 true => Ok(()),
@@ -158,8 +158,8 @@ fn validate_volume_mounts(
         }
         settings::Reject::AnyNotIn => {
             // allowlist
-            let difference: HashSet<_> = volume_mount_names
-                .difference(&settings.volume_mount_names)
+            let difference: HashSet<_> = volume_mounts_names
+                .difference(&settings.volume_mounts_names)
                 .collect();
             match difference.is_empty() {
                 true => Ok(()),
@@ -173,8 +173,8 @@ fn validate_volume_mounts(
         settings::Reject::NotAllAreUsed => {
             // can use both at once, but not only one of them
             let difference: HashSet<_> = settings
-                .volume_mount_names
-                .difference(&volume_mount_names)
+                .volume_mounts_names
+                .difference(&volume_mounts_names)
                 .collect();
             match difference.is_empty() {
                 true => Ok(()),
@@ -217,7 +217,7 @@ mod tests {
             expected_validation_result: true,
             settings: Settings {
                 operator: settings::Reject::AnyIn,
-                volume_mount_names: HashSet::from([String::from("test1")]),
+                volume_mounts_names: HashSet::from([String::from("test1")]),
             },
         };
 
@@ -234,7 +234,7 @@ mod tests {
             expected_validation_result: false,
             settings: Settings {
                 operator: settings::Reject::AnyIn,
-                volume_mount_names: HashSet::from([
+                volume_mounts_names: HashSet::from([
                     String::from("test-var"),
                     String::from("test-data"),
                 ]),
@@ -259,7 +259,7 @@ container init-myservice2 is invalid: volumeMount names not allowed: [\"test-var
             expected_validation_result: true,
             settings: Settings {
                 operator: settings::Reject::AnyNotIn,
-                volume_mount_names: HashSet::from([
+                volume_mounts_names: HashSet::from([
                     String::from("test-var"),
                     String::from("test-data"),
                     String::from("test-var-local-aaa"),
@@ -281,7 +281,7 @@ container init-myservice2 is invalid: volumeMount names not allowed: [\"test-var
             expected_validation_result: false,
             settings: Settings {
                 operator: settings::Reject::AnyNotIn,
-                volume_mount_names: HashSet::from([String::from("unexistent")]),
+                volume_mounts_names: HashSet::from([String::from("unexistent")]),
             },
         };
 
@@ -305,7 +305,7 @@ container init-myservice2 is invalid: volumeMount names not allowed: [\"test-var
             expected_validation_result: true,
             settings: Settings {
                 operator: settings::Reject::AllAreUsed,
-                volume_mount_names: HashSet::from([
+                volume_mounts_names: HashSet::from([
                     String::from("test-var"),
                     String::from("unexistent"),
                 ]),
@@ -325,7 +325,7 @@ container init-myservice2 is invalid: volumeMount names not allowed: [\"test-var
             expected_validation_result: false,
             settings: Settings {
                 operator: settings::Reject::AllAreUsed,
-                volume_mount_names: HashSet::from([
+                volume_mounts_names: HashSet::from([
                     String::from("test-var"),
                     String::from("test-var-local-aaa"),
                 ]),
@@ -348,7 +348,7 @@ container init-myservice2 is invalid: volumeMount names not allowed: [\"test-var
             expected_validation_result: true,
             settings: Settings {
                 operator: settings::Reject::NotAllAreUsed,
-                volume_mount_names: HashSet::from([
+                volume_mounts_names: HashSet::from([
                     String::from("test-var"),
                     String::from("test-var-local-aaa"),
                 ]),
@@ -368,7 +368,7 @@ container init-myservice2 is invalid: volumeMount names not allowed: [\"test-var
             expected_validation_result: false,
             settings: Settings {
                 operator: settings::Reject::NotAllAreUsed,
-                volume_mount_names: HashSet::from([
+                volume_mounts_names: HashSet::from([
                     String::from("test-var"),
                     String::from("nonexistent"),
                 ]),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -23,6 +23,9 @@ pub enum Reject {
 
 impl kubewarden::settings::Validatable for Settings {
     fn validate(&self) -> Result<(), String> {
+        if self.volume_mounts_names.is_empty() {
+            return Err("volumeMountsNames is empty".to_string());
+        }
         Ok(())
     }
 }
@@ -30,6 +33,7 @@ impl kubewarden::settings::Validatable for Settings {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use kubewarden_policy_sdk::settings::Validatable;
 
     #[test]
     fn test_policy_with_no_settings() -> Result<(), ()> {
@@ -41,6 +45,10 @@ mod tests {
         assert!(
             matches!(settings.as_ref().unwrap().operator, Reject::AnyIn),
             "operator should be 'anyIn' when not defined by the user"
+        );
+        assert!(
+            settings.unwrap().validate().is_err(),
+            "validating empty settings should fail as empty names set"
         );
         Ok(())
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Settings {
     pub operator: Reject,
-    pub volume_mount_names: HashSet<String>,
+    pub volume_mounts_names: HashSet<String>,
 }
 
 #[derive(Serialize, Deserialize, Default, Debug)]
@@ -49,7 +49,7 @@ mod tests {
     fn test_policy_with_settings() -> Result<(), serde_yaml::Error> {
         let payload = "
 operator: anyNotIn
-volumeMountNames:
+volumeMountsNames:
   - test1
 ";
         let settings = serde_yaml::from_str::<Settings>(payload);
@@ -61,7 +61,7 @@ volumeMountNames:
         assert!(settings
             .as_ref()
             .unwrap()
-            .volume_mount_names
+            .volume_mounts_names
             .contains(&"test1".to_string()));
         Ok(())
     }

--- a/test_data/settings_reject.yaml
+++ b/test_data/settings_reject.yaml
@@ -1,4 +1,4 @@
 reject: AnyIn
-volumeMountNames:
+volumeMountsNames:
   - test-var
   - test-data


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
- fix: Use `volumeMountsNames` everywhere, error if empty
- Bump to version 0.1.2

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

Run new tests.

## Addtional information

Unblocks https://github.com/kubewarden/kubewarden.io/pull/139.


