### PR TITLE
Bump v0.1.7 policy version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "volumemounts-policy"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volumemounts-policy"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Víctor Cuadrado Juan <vcuadradojuan@suse.de>"]
 edition = "2018"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,16 +4,16 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.6
+version: 0.1.7
 name: volumemounts
 displayName: volumeMounts
-createdAt: 2023-03-24T16:19:59.447917909Z
+createdAt: 2023-07-10T16:03:04.118723956Z
 description: Policy that inspects containers, init containers, and ephemeral containers, and restricts their usage of volumes by  checking the `volume` name being used in `volumeMounts[*].name`
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/volumemounts-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/volumemounts:v0.1.6
+  image: ghcr.io/kubewarden/policies/volumemounts:v0.1.7
 keywords:
 - container
 - volumeMounts
@@ -22,13 +22,13 @@ keywords:
 - workload resources
 links:
 - name: policy
-  url: https://github.com/kubewarden/volumemounts-policy/releases/download/v0.1.6/policy.wasm
+  url: https://github.com/kubewarden/volumemounts-policy/releases/download/v0.1.7/policy.wasm
 - name: source
   url: https://github.com/kubewarden/volumemounts-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/volumemounts:v0.1.6
+  kwctl pull ghcr.io/kubewarden/policies/volumemounts:v0.1.7
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
Bump v0.1.7 policy version.        

Updates files bumping the policy version to v0.1.7

Related to https://github.com/kubewarden/kubewarden-controller/issues/479
